### PR TITLE
Add drogue event source to grafana example and make it default

### DIFF
--- a/charts/drogue-cloud-examples/templates/integration/kafka-secrets.yaml
+++ b/charts/drogue-cloud-examples/templates/integration/kafka-secrets.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.source.kafka.enabled -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ metadata:
     app.kubernetes.io/part-of: example-app
 data:
   {{- include "drogue-cloud-common.knative-kafka-net-secret-data" (dict "root" . "userName" "example-user") | nindent 2 }}
+{{- end -}}

--- a/charts/drogue-cloud-examples/templates/integration/kafka-topic.yaml
+++ b/charts/drogue-cloud-examples/templates/integration/kafka-topic.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.kafka.external.enabled -}}
+{{- if and (.Values.source.kafka.enabled) (not .Values.kafka.external.enabled) -}}
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:

--- a/charts/drogue-cloud-examples/templates/integration/kafka-user.yaml
+++ b/charts/drogue-cloud-examples/templates/integration/kafka-user.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.kafka.external.enabled -}}
+{{- if and (.Values.source.kafka.enabled) (not .Values.kafka.external.enabled) -}}
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:

--- a/charts/drogue-cloud-examples/templates/pusher/deployment.yaml
+++ b/charts/drogue-cloud-examples/templates/pusher/deployment.yaml
@@ -1,0 +1,72 @@
+{{- if and (.Values.pusher.enabled) (not .Values.pusher.knative) -}}
+{{- $ref := dict "root" . "name" "timescaledb-pusher" "component" "pusher" -}}
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: timescaledb-pusher
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: timescaledb-pusher
+  template:
+    metadata:
+      labels:
+        app: timescaledb-pusher
+    spec:
+      containers:
+        - name: timescaledb-pusher
+          image: {{ .Values.pusher.image }}
+          imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 8080
+            name: web
+            protocol: TCP
+          env:
+            - name: RUST_LOG
+              value: debug
+            - name: RUST_BACKTRACE
+              value: "1"
+
+            - name: ACTIX__BIND_ADDR
+              value: 0.0.0.0:8080
+
+            - name: POSTGRESQL__CONNECTION__HOST
+              value: timescaledb
+            - name: POSTGRESQL__CONNECTION__DBNAME
+              value: {{ .Values.timescale.database.name }}
+            - name: POSTGRESQL__CONNECTION__USER
+              value: {{ .Values.timescale.database.adminUser }}
+            - name: POSTGRESQL__CONNECTION__PASSWORD
+              value: {{ .Values.timescale.database.adminPassword }}
+
+            - name: POSTGRESQL__TIME_COLUMN
+              value: time
+
+            - name: POSTGRESQL__TABLE
+              value: temperatures
+
+            - name: FIELD_TEMPERATURE
+              value: $.temp
+            - name: TYPE_FIELD_TEMPERATURE
+              value: float
+            - name: FIELD_BATTERY
+              value: $.batt
+            - name: TYPE_FIELD_BATTERY
+              value: float
+            - name: FIELD_HUMIDITY
+              value: $.hum
+            - name: TYPE_FIELD_HUMIDITY
+              value: float
+            - name: TAG_DEVICE_ID
+              value: $.device
+
+            - name: FIELD_LAT
+              value: $.geoloc.lat
+            - name: TYPE_FIELD_LAT
+              value: float
+            - name: FIELD_LON
+              value: $.geoloc.lon
+            - name: TYPE_FIELD_LON
+              value: float
+{{- end -}}

--- a/charts/drogue-cloud-examples/templates/pusher/knative-service.yaml
+++ b/charts/drogue-cloud-examples/templates/pusher/knative-service.yaml
@@ -1,3 +1,4 @@
+{{- if and (.Values.pusher.enabled) (.Values.pusher.knative) -}}
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
@@ -11,7 +12,7 @@ spec:
   template:
     spec:
       containers:
-        - image: {{ .Values.timescale.pusher.image }}
+        - image: {{ .Values.pusher.image }}
           env:
             - name: RUST_LOG
               value: debug
@@ -60,3 +61,4 @@ spec:
           resources:
             limits:
               memory: 64Mi
+{{- end -}}

--- a/charts/drogue-cloud-examples/templates/pusher/service.yaml
+++ b/charts/drogue-cloud-examples/templates/pusher/service.yaml
@@ -1,0 +1,15 @@
+{{- if and (.Values.pusher.enabled) (not .Values.pusher.knative) -}}
+kind: Service
+apiVersion: v1
+metadata:
+  labels:
+    app: timescaledb-pusher
+  name: timescaledb-pusher
+spec:
+  ports:
+    - name: web
+      port: 8080
+      protocol: TCP
+  selector:
+    app: timescaledb-pusher
+{{- end -}}

--- a/charts/drogue-cloud-examples/templates/source/drogue/deployment.yaml
+++ b/charts/drogue-cloud-examples/templates/source/drogue/deployment.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.source.drogue.enabled -}}
+{{- $ref := dict "root" . "name" "drogue-event-source" "component" "source" -}}
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: drogue-event-source
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: drogue-event-source
+  template:
+    metadata:
+      labels:
+        app: drogue-event-source
+    spec:
+      containers:
+        - name: drogue-event-source
+          image: {{ .Values.source.drogue.image }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: RUST_LOG
+              value: debug
+            - name: RUST_BACKTRACE
+              value: "1"
+
+            - name: K_SINK
+              value: http://timescaledb-pusher:8080
+            - name: DROGUE_ENDPOINT
+              value: {{ .Values.source.drogue.endpoint }}
+            - name: DROGUE_TOKEN
+              value: {{ .Values.source.drogue.token }}
+            - name: DROGUE_APP
+              value: {{ .Values.drogueApplication.name }}
+{{- end -}}

--- a/charts/drogue-cloud-examples/templates/source/kafka/kafka-source.yaml
+++ b/charts/drogue-cloud-examples/templates/source/kafka/kafka-source.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.source.kafka.enabled -}}
 apiVersion: sources.knative.dev/{{ .Values.knative.kafkaSource.apiVersion }}
 kind: KafkaSource
 metadata:
@@ -21,3 +22,4 @@ spec:
       apiVersion: v1
       kind: Service
       name: timescaledb-pusher
+{{- end -}}

--- a/charts/drogue-cloud-examples/values.yaml
+++ b/charts/drogue-cloud-examples/values.yaml
@@ -3,7 +3,7 @@ global:
   domain: .my-cluster.dns
 
 drogueApplication:
-  name: example-app
+  name: drogue-public-temperature
   # eventTopic can provide an explicit event topic
   # eventTopic: <topic name>
 
@@ -51,5 +51,19 @@ timescale:
     name: example
   postInstall:
     image: docker.io/library/postgres:14
-  pusher:
-    image: ghcr.io/drogue-iot/postgresql-pusher:0.1.0
+
+pusher:
+  enabled: true
+  knative: false
+  image: ghcr.io/drogue-iot/postgresql-pusher:0.1.0
+
+source:
+  kafka:
+    enabled: false
+  drogue:
+    enabled: true
+    image: ghcr.io/drogue-iot/drogue-event-source:0.1.0
+    endpoint: wss://ws-integration.sandbox.drogue.cloud
+    # Grab your token with `drg whoami -t`
+    # token: XXX
+    sink: http://timescaledb-pusher:8080


### PR DESCRIPTION
This adds https://github.com/drogue-iot/drogue-event-source to the Grafana example and makes it default source. It installs without requirements for Knative and Kafka. It connects to Drogue Cloud using WebSockets for now. It is still possible to run the example using Kafka source and Knative.
An example of how to run it on Minikube
```
helm install --dependency-update --set global.domain=.$(minikube ip).nip.io drogue-cloud-examples charts/drogue-cloud-examples/
```
It will try to automatically connect to the sandbox and consume data for `drogue-public-temperature` app.

