### PR TITLE
Enable cloud-based Kubernetes versions

### DIFF
--- a/charts/drogue-cloud-core/Chart.yaml
+++ b/charts/drogue-cloud-core/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 version: 0.5.0-alpha1
 appVersion: 0.9.0
 
-kubeVersion: ">= 1.19.0"
+kubeVersion: ">= 1.19.0-0"
 
 dependencies:
   - name: drogue-cloud-common

--- a/charts/drogue-cloud-examples/Chart.yaml
+++ b/charts/drogue-cloud-examples/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 version: 0.5.0-alpha1
 appVersion: 0.9.0
 
-kubeVersion: ">= 1.19.0"
+kubeVersion: ">= 1.19.0-0"
 
 dependencies:
   - name: drogue-cloud-common

--- a/charts/drogue-cloud-twin/Chart.yaml
+++ b/charts/drogue-cloud-twin/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 version: 0.5.0-alpha1
 appVersion: 0.9.0
 
-kubeVersion: ">= 1.19.0"
+kubeVersion: ">= 1.19.0-0"
 
 dependencies:
   - name: drogue-cloud-common


### PR DESCRIPTION
The minimum version of Kubernetes required for the `drogue-cloud-core` chart is is incompatible with GKE/EKS versions of Kubernetes due to semver rules.

kubernetes/kubernetes#89404

This should resolve an issue I am current having:

`Error: chart requires kubeVersion: >= 1.19.0 which is incompatible with Kubernetes v1.21.5-gke.1302`

**Note:** I have not tested this on all the supported platforms.
