### PR TITLE
Add jaeger deployment to minikube

### DIFF
--- a/charts/drogue-cloud-metrics/Chart.yaml
+++ b/charts/drogue-cloud-metrics/Chart.yaml
@@ -33,4 +33,4 @@ dependencies:
   - name: jaeger-operator
     version: ~2.27
     repository: "https://jaegertracing.github.io/helm-charts"
-    condition: tracing.enabled
+    condition: .global.drogueCloud.jaeger.deployOperator

--- a/charts/drogue-cloud-metrics/Chart.yaml
+++ b/charts/drogue-cloud-metrics/Chart.yaml
@@ -30,3 +30,7 @@ dependencies:
     version: ~6.16.0
     repository: "https://grafana.github.io/helm-charts"
     condition: grafana.enabled
+  - name: jaeger-operator
+    version: ~2.27
+    repository: "https://jaegertracing.github.io/helm-charts"
+    condition: tracing.enabled

--- a/charts/drogue-cloud-metrics/templates/tracing/jaeger.yaml
+++ b/charts/drogue-cloud-metrics/templates/tracing/jaeger.yaml
@@ -1,0 +1,11 @@
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: drogue-tracing
+spec:
+  strategy: allInOne
+  sampling:
+    options:
+      default_strategy:
+        type: probabilistic
+        param: 0.5

--- a/charts/drogue-cloud-metrics/templates/tracing/jaeger.yaml
+++ b/charts/drogue-cloud-metrics/templates/tracing/jaeger.yaml
@@ -1,11 +1,10 @@
 apiVersion: jaegertracing.io/v1
 kind: Jaeger
 metadata:
-  name: drogue-tracing
+  name: jaeger
 spec:
-  strategy: allInOne
-  sampling:
-    options:
-      default_strategy:
-        type: probabilistic
-        param: 0.5
+  {{- if has .Values.global.cluster (list "minikube" "kind" ) }}
+  ingress:
+    hosts:
+      - {{ include "drogue-cloud-common.ingress.host" (dict "root" . "prefix" "jaeger" "ingress" .root.Values.global.drogueCloud.jaeger.ingress ) }}
+  {{- end}}

--- a/charts/drogue-cloud-metrics/values.yaml
+++ b/charts/drogue-cloud-metrics/values.yaml
@@ -39,7 +39,3 @@ grafana:
     datasources:
       enabled: true
       label: grafana_datasource
-
-# in openshift we use the jaeger operator
-tracing:
-  enabled: false

--- a/charts/drogue-cloud-metrics/values.yaml
+++ b/charts/drogue-cloud-metrics/values.yaml
@@ -39,3 +39,7 @@ grafana:
     datasources:
       enabled: true
       label: grafana_datasource
+
+# in openshift we use the jaeger operator
+tracing:
+  enabled: false


### PR DESCRIPTION
add to ` minikube.yaml` profile : 
```yaml
drogueCloudCore:
  global:
    drogueCloud:
      jaeger:
        enabled: true

drogueCloudMetrics:
  tracing:
    enabled: true
```

TODO : 

- [x] Revisit the all in one jaeger instance ?
- [x] Add an Ingress for the jaeger-query UI