### PR TITLE
metrics test if the grafana secret exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: update
 
 .PHONY: update
 update:
-	for i in common core examples twin; do \
+	for i in common core examples metrics twin; do \
 		helm dep up charts/drogue-cloud-$$i; \
 	done
 

--- a/charts/drogue-cloud-metrics/templates/grafana/grafana-datasource-secret.yaml
+++ b/charts/drogue-cloud-metrics/templates/grafana/grafana-datasource-secret.yaml
@@ -22,9 +22,9 @@ stringData:
       editable: false
       jsonData:
         tlsSkipVerify: {{ .Values.grafana.datasource.tlsSkipVerify }}
-{{- if len .Values.grafana.datasource.token }}
+    {{- if .Values.grafana.datasource.token }}
         httpHeaderName1: "Authorization"
       secureJsonData:
         httpHeaderValue1: {{ ( printf "Bearer %s" .Values.grafana.datasource.token ) | quote }}
-{{ end }}
+    {{ end }}
 {{- end }}


### PR DESCRIPTION
fixes https://github.com/drogue-iot/drogue-cloud/issues/225

This seems to fix the linting at least. 
Was the `len` here to prevent the case of a token that would be just an empty string ?